### PR TITLE
Fix warnings from auto_ptr deprecation

### DIFF
--- a/buffer.cc
+++ b/buffer.cc
@@ -81,7 +81,7 @@ buffer :: cmp(const char* buf, size_t sz) const
 buffer*
 buffer :: copy() const
 {
-    std::auto_ptr<buffer> ret(create(m_cap));
+    std::unique_ptr<buffer> ret(create(m_cap));
     ret->m_cap = m_cap;
     ret->m_size = m_size;
     memmove(ret->m_data, m_data, m_cap);

--- a/e/lockfree_fifo.h
+++ b/e/lockfree_fifo.h
@@ -81,7 +81,7 @@ lockfree_fifo<T> :: lockfree_fifo()
 template <typename T>
 lockfree_fifo<T> :: ~lockfree_fifo() throw ()
 {
-    std::auto_ptr<typename hazard_ptrs<node, 2>::hazard_ptr> hptr = m_hazards.get();
+    std::unique_ptr<typename hazard_ptrs<node, 2>::hazard_ptr> hptr = m_hazards.get();
 
     while (m_head)
     {
@@ -95,10 +95,10 @@ template <typename T>
 void
 lockfree_fifo<T> :: push(T& val)
 {
-    std::auto_ptr<typename hazard_ptrs<node, 2>::hazard_ptr> hptr = m_hazards.get();
+    std::unique_ptr<typename hazard_ptrs<node, 2>::hazard_ptr> hptr = m_hazards.get();
     node* tail;
     node* next;
-    std::auto_ptr<node> n(new node(NULL, val));
+    std::unique_ptr<node> n(new node(NULL, val));
 
     while (true)
     {
@@ -142,7 +142,7 @@ template <typename T>
 bool
 lockfree_fifo<T> :: pop(T* val)
 {
-    std::auto_ptr<typename hazard_ptrs<node, 2>::hazard_ptr> hptr = m_hazards.get();
+    std::unique_ptr<typename hazard_ptrs<node, 2>::hazard_ptr> hptr = m_hazards.get();
     node* head;
     node* tail;
     node* next;

--- a/e/lockfree_hash_map.h
+++ b/e/lockfree_hash_map.h
@@ -68,7 +68,7 @@ class lockfree_hash_map
         };
 
         class node;
-        typedef std::auto_ptr<typename hazard_ptrs<node, 3>::hazard_ptr> hazard_ptr;
+        typedef std::unique_ptr<typename hazard_ptrs<node, 3>::hazard_ptr> hazard_ptr;
 
     private:
         lockfree_hash_map(const lockfree_hash_map&);
@@ -235,7 +235,7 @@ lockfree_hash_map<K, V, H> :: insert(const K& k, const V& v)
         }
 
         assert(is_clean(cur));
-        std::auto_ptr<node> nn(new node(hash, k, v, cur));
+        std::unique_ptr<node> nn(new node(hash, k, v, cur));
         node* inserted = e::bitsteal::set(nn.get(), VALID);
 
         if (cas(prev, cur, inserted))

--- a/test/buffer.cc
+++ b/test/buffer.cc
@@ -43,15 +43,15 @@ namespace
 TEST(BufferTest, CtorAndDtor)
 {
     // Create a buffer without any size
-    std::auto_ptr<e::buffer> a(e::buffer::create(0));
+    std::unique_ptr<e::buffer> a(e::buffer::create(0));
     ASSERT_EQ(0U, a->size());
     ASSERT_EQ(0U, a->capacity());
     // Create a buffer which can pack 2 bytes
-    std::auto_ptr<e::buffer> b(e::buffer::create(2));
+    std::unique_ptr<e::buffer> b(e::buffer::create(2));
     ASSERT_EQ(0U, b->size());
     ASSERT_EQ(2U, b->capacity());
     // Create a buffer with the three bytes "XYZ"
-    std::auto_ptr<e::buffer> c(e::buffer::create("xyz", 3));
+    std::unique_ptr<e::buffer> c(e::buffer::create("xyz", 3));
     ASSERT_EQ(3U, c->size());
     ASSERT_EQ(3U, c->capacity());
 }
@@ -62,8 +62,8 @@ TEST(BufferTest, PackBuffer)
     uint32_t b = 0x8badf00d;
     uint16_t c = 0xface;
     uint8_t d = '!';
-    std::auto_ptr<e::buffer> buf(e::buffer::create("the buffer", 10));
-    std::auto_ptr<e::buffer> packed(e::buffer::create(34));
+    std::unique_ptr<e::buffer> buf(e::buffer::create("the buffer", 10));
+    std::unique_ptr<e::buffer> packed(e::buffer::create(34));
 
     packed->pack() << a << b << c << d << buf->as_slice();
     ASSERT_EQ(26U, packed->size());
@@ -93,7 +93,7 @@ TEST(BufferTest, UnpackBuffer)
     uint16_t c;
     uint8_t d;
     e::slice sl;
-    std::auto_ptr<e::buffer> packed(e::buffer::create(
+    std::unique_ptr<e::buffer> packed(e::buffer::create(
                 "\xde\xad\xbe\xef\xca\xfe\xba\xbe"
                 "\x8b\xad\xf0\x0d"
                 "\xfa\xce"
@@ -111,7 +111,7 @@ TEST(BufferTest, UnpackBuffer)
 
 TEST(BufferTest, UnpackErrors)
 {
-    std::auto_ptr<e::buffer> buf(e::buffer::create("\x8b\xad\xf0\x0d" "\xfa\xce", 6));
+    std::unique_ptr<e::buffer> buf(e::buffer::create("\x8b\xad\xf0\x0d" "\xfa\xce", 6));
     uint32_t a;
     e::unpacker up = buf->unpack() >> a;
     ASSERT_EQ(0x8badf00d, a);
@@ -135,8 +135,8 @@ TEST(BufferTest, UnpackErrors)
 
 TEST(BufferTest, Hex)
 {
-    std::auto_ptr<e::buffer> buf1(e::buffer::create("\xde\xad\xbe\xef", 4));
-    std::auto_ptr<e::buffer> buf2(e::buffer::create("\x00\xff\x0f\xf0", 4));
+    std::unique_ptr<e::buffer> buf1(e::buffer::create("\xde\xad\xbe\xef", 4));
+    std::unique_ptr<e::buffer> buf2(e::buffer::create("\x00\xff\x0f\xf0", 4));
 
     ASSERT_EQ("deadbeef", buf1->hex());
     ASSERT_EQ("00ff0ff0", buf2->hex());
@@ -144,7 +144,7 @@ TEST(BufferTest, Hex)
 
 TEST(BufferTest, VectorPack)
 {
-    std::auto_ptr<e::buffer> buf(e::buffer::create(12));
+    std::unique_ptr<e::buffer> buf(e::buffer::create(12));
     std::vector<uint16_t> vector;
     vector.push_back(0xdead);
     vector.push_back(0xbeef);
@@ -159,7 +159,7 @@ TEST(BufferTest, VectorPack)
 
 TEST(BufferTest, VectorUnpack)
 {
-    std::auto_ptr<e::buffer> buf(e::buffer::create("\x04"
+    std::unique_ptr<e::buffer> buf(e::buffer::create("\x04"
                                                    "\xde\xad\xbe\xef"
                                                    "\xca\xfe\xba\xbe", 9));
     std::vector<uint16_t> vector;
@@ -173,7 +173,7 @@ TEST(BufferTest, VectorUnpack)
 
 TEST(BufferTest, VectorUnpackFail)
 {
-    std::auto_ptr<e::buffer> buf(e::buffer::create("\x04"
+    std::unique_ptr<e::buffer> buf(e::buffer::create("\x04"
                                                    "\xde\xad\xbe\xef"
                                                    "\xca\xfe\xba\xbe", 9));
     std::vector<uint32_t> vector_bad;


### PR DESCRIPTION
## Summary
- replace deprecated `std::auto_ptr` with `std::unique_ptr`
- update buffer tests and hazard pointer utilities

## Testing
- `make clean`
- `make check > /tmp/make_check.log 2>&1`
